### PR TITLE
Do not modify the OpenidClient object when pickling it

### DIFF
--- a/src/simple_openid_connect/client.py
+++ b/src/simple_openid_connect/client.py
@@ -254,7 +254,7 @@ class OpenidClient:
     def __getstate__(self) -> Mapping[str, Any]:
         # this implements support for pickling this class
         # it is basically the default pickle behavior but explicitly serializes keys because they are FFI backed and not normally picklable
-        result = self.__dict__
+        result = self.__dict__.copy()
         result["provider_keys"] = [k.serialize() for k in self.provider_keys]
         return result
 


### PR DESCRIPTION
Modifying `self.__dict__` in `OpenidClient` modifies the object as well. This led to invalid `provider_keys` when the object was first put in the cache, but valid keys when the object is is first retrieved from the cache. We can avoid that by using a copy of the dict.
Closes #2.