### PR TITLE
Refactor django user mapping

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,6 +37,23 @@ pip install -e .[django,djangorestframework] -r requirements.dev.txt
 pytest
 ```
 
+## How to build the Documentation
+
+Assuming that the virtual environment is already activated, the following commands can be executed to build a local
+version of the projects documentation.
+
+```shell
+cd docs
+make html
+```
+
+Afterwards, the documentation is available as html files under `docs/_build/html`.
+To view it, either open the files directly in your browser or use your favourite local http server to serve the content
+(e.g. by running `python -m http.server -d docs/_build/html 8080`).
+
+Sometimes, a clean build is required to update the documentation extracted from the source code.
+This can be done by running `make clean`.
+
 ## How to release
 
 In order to release a new version, the following steps are necessary:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,6 +31,12 @@ source ./venv/bin/activate
 pip install -e .[django,djangorestframework] -r requirements.dev.txt
 ```
 
+## How to run the Tests
+
+```shell
+pytest
+```
+
 ## How to release
 
 In order to release a new version, the following steps are necessary:

--- a/docs/django-integration.rst
+++ b/docs/django-integration.rst
@@ -56,11 +56,11 @@ Recommended settings
     The Openid scopes which are requested from the provider when a user logs in.
     It should be a list of scopes as space separated string and should contain the ``openid`` scope.
 
-- ``LOGIN_URL`` (`django docs <https://docs.djangoproject.com/en/dev/ref/settings/#login-url>`_)
+- ``LOGIN_URL`` (`django LOGIN_URL docs <https://docs.djangoproject.com/en/dev/ref/settings/#login-url>`_)
     This is recommended to be set to ``simple_openid_connect_django:login`` to serve this libraries login page which handles Openid authentication.
     If additional authentication methods are also used, don't do this.
 
-- ``LOGOUT_REDIRECT_URL`` (`django docs <https://docs.djangoproject.com/en/dev/ref/settings/#logout-redirect-url>`_)
+- ``LOGOUT_REDIRECT_URL`` (`django LOGOUT_REDIRECT_URL docs <https://docs.djangoproject.com/en/dev/ref/settings/#logout-redirect-url>`_)
     This is the url the user is redirected to after logging out. If it is not set, some Openid providers do not redirect the user back to the application.
 
 Usage

--- a/docs/django-integration.rst
+++ b/docs/django-integration.rst
@@ -74,15 +74,37 @@ It interoperates with Django's builtin authentication so things like the ``login
 If you want to authenticate a user via Openid, simply visit ``/auth/openid/login`` on your app.
 
 
-Customizing User Mapping
-------------------------
+Custom User Mapping
+-------------------
 
-User objects are automatically created from id tokens and also updated when the user re-authenticates.
-The default behavior is to look for some well known id token attributes and map them to well known django attributes.
-See :mod:`user_mapping <simple_openid_connect.integrations.django.user_mapping>` for the implementation.
+User objects are automatically created when the user authenticates to a django server using this integration.
+This is done when the server is a relying party as well as when it is a resource server.
+The goal is to be as transparent as possible to programmers because a user object is always available and associated
+with authenticated requests.
 
-This can be customized by defining ``OPENID_CREATE_USER_FUNC`` or ``OPENID_UPDATE_USER_FUNC`` in your django settings.
-These should be a dotted module path with the function being the last name in the path.
+Sometimes it is useful though to customize the behavior in which tokens are mapped to users or which information
+is extracted from the tokens.
+This can be done in two steps:
+
+1. Subclass :class:`UserMapper <simple_openid_connect.integrations.django.user_mapping.UserMapper>` and overwrite the
+   methods which should be changed.
+
+   For details about which methods exist on the class, what they should do and what their signatures are, take a look
+   at the ``UserMapper`` class documentation.
+
+   .. code-block:: python
+
+      from simple_openid_connect.integrations.django.user_mapping import UserMapper
+
+      class CustomUserMapper(UserMapper):
+          def automap_user_attrs(self, user, user_data):
+              super().automap_user_attrs(self, user, user_data)
+              if user_data.preferred_username == "admin":
+                  user.is_superuser = True
+                  user.is_staff = True
+
+2. Configure simple_openid_connect to use the new ``UserMapper`` class by setting the ``OPENID_USER_MAPPER`` attribute
+   in your projects ``settings.py``.
 
 
 Accessing ``OpenidClient``

--- a/src/simple_openid_connect/base_data.py
+++ b/src/simple_openid_connect/base_data.py
@@ -87,7 +87,7 @@ class OpenidBaseModel(BaseModel, metaclass=abc.ABCMeta):
             raise ValueError(f"invalid location value {location}")
 
     @classmethod
-    def parse_jws(cls: Type[Self], value: str, signing_keys: List[JWK]) -> Self:
+    def parse_jwt(cls: Type[Self], value: str, signing_keys: List[JWK]) -> Self:
         """
         Parse received data that is encoded as a signed Json-Web-Signature (JWS).
 
@@ -96,15 +96,4 @@ class OpenidBaseModel(BaseModel, metaclass=abc.ABCMeta):
         """
         verifier = JWS()
         msg = verifier.verify_compact(value, signing_keys)
-        return cls.parse_obj(msg)
-
-    @classmethod
-    def parse_jwt(
-        cls: Type[Self], token: str, signing_keys: List[JWK], issuer: str
-    ) -> Self:
-        key_bundle = KeyBundle(keys=signing_keys)
-        key_jar = KeyJar()
-        key_jar.add_kb(issuer, key_bundle)
-        verifier = JWT(key_jar)
-        msg = verifier.unpack(token)
         return cls.parse_obj(msg)

--- a/src/simple_openid_connect/client.py
+++ b/src/simple_openid_connect/client.py
@@ -226,7 +226,7 @@ class OpenidClient:
 
         :raises ValidationError: if the validation fails
         """
-        token = IdToken.parse_jws(raw_token, self.provider_keys)
+        token = IdToken.parse_jwt(raw_token, self.provider_keys)
         token.validate_extern(
             issuer=self.provider_config.issuer,
             client_id=self.client_auth.client_id,

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -304,7 +304,7 @@ class JwtAccessToken(OpenidBaseModel):
 
     .. note::
 
-        While the RFC defines some fields to be required, some vendors issue tokens that look they conform to the RFC
+        While the RFC defines some fields to be required, some vendors issue tokens that look like they conform to the RFC
         but in fact do not because some required fields are missing.
         To allow usage of these tokens even though they do not strictly conform to the RFC, almost all fields are marked
         optional.
@@ -349,18 +349,18 @@ class JwtAccessToken(OpenidBaseModel):
 
     def validate_extern(self, issuer: str) -> None:
         """
-        Validate this Access-Token with external data for consistency.
+        Validate this access token with external data for consistency.
 
         :param issuer: The issuer that this token is supposed to originate from.
             Should usually be :data:`ProviderMetadata.issuer`.
         """
         # validate issuer
         validate_that(
-            self.iss == issuer, "Access-Token was issued from unexpected issuer"
+            self.iss == issuer, "The access token was issued from unexpected issuer"
         )
 
         # validate expiry
-        validate_that(self.exp > time.time(), "The Access-Token is expired")
+        validate_that(self.exp > time.time(), "The access token is expired")
 
 
 class UserinfoRequest(OpenidBaseModel):

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -301,6 +301,13 @@ class JwtAccessToken(OpenidBaseModel):
     The specification defines a profile for issuing access tokens in JSON Web Token (JWT) format.
     Authorization servers from different vendors may leverage this profile to issue access tokens in an interoperable
     manner but they are in no way required to do so.
+
+    .. note::
+
+        While the RFC defines some fields to be required, some vendors issue tokens that look they conform to the RFC
+        but in fact do not because some required fields are missing.
+        To allow usage of these tokens even though they do not strictly conform to the RFC, almost all fields are marked
+        optional.
     """
 
     class Config:
@@ -308,25 +315,25 @@ class JwtAccessToken(OpenidBaseModel):
         allow_mutation = False
 
     iss: AnyHttpUrl
-    "REQUIRED. The 'iss' (issuer) claim identifies the principal that issued the JWT. The processing of this claim is generally application specific. The 'iss' value is a case-sensitive string containing a StringOrURI value."
+    "The 'iss' (issuer) claim identifies the principal that issued the JWT. The processing of this claim is generally application specific. The 'iss' value is a case-sensitive string containing a StringOrURI value."
 
     exp: int
-    "REQUIRED. The 'exp' (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. The processing of the 'exp' claim requires that the current date/time MUST be before the expiration date/time listed in the 'exp' claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value."
+    "The 'exp' (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. The processing of the 'exp' claim requires that the current date/time MUST be before the expiration date/time listed in the 'exp' claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value."
 
-    aud: str
-    "REQUIRED. The 'aud' (audience) claim identifies the recipients that the JWT is intended for. Each principal intended to process the JWT MUST identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the 'aud' claim when this claim is present, then the JWT MUST be rejected. In the general case, the 'aud' value is an array of case-sensitive strings, each containing a StringOrURI value. In the special case when the JWT has one audience, the 'aud' value MAY be a single case-sensitive string containing a StringOrURI value. The interpretation of audience values is generally application specific."
+    aud: Optional[str]
+    "The 'aud' (audience) claim identifies the recipients that the JWT is intended for. Each principal intended to process the JWT MUST identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the 'aud' claim when this claim is present, then the JWT MUST be rejected. In the general case, the 'aud' value is an array of case-sensitive strings, each containing a StringOrURI value. In the special case when the JWT has one audience, the 'aud' value MAY be a single case-sensitive string containing a StringOrURI value. The interpretation of audience values is generally application specific."
 
-    sub: str
-    "REQUIRED. Subject Identifier A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4 It MUST NOT exceed 255 ASCII characters in length The sub value is a case sensitive string."
+    sub: Optional[str]
+    "Subject Identifier A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4 It MUST NOT exceed 255 ASCII characters in length The sub value is a case sensitive string."
 
-    client_id: str
-    "REQUIRED. The client_id claim carries the client identifier of the OpenId client that requested the token."
+    client_id: Optional[str]
+    "The client_id claim carries the client identifier of the OpenId client that requested the token."
 
-    iat: int
-    "REQUIRED. As defined in Section 4.1.6 of [RFC7519]. This claim identifies the time at which the JWT access token was issued."
+    iat: Optional[int]
+    "As defined in Section 4.1.6 of [RFC7519]. This claim identifies the time at which the JWT access token was issued."
 
-    jti: str
-    "REQUIRED. Unique identifier for the token."
+    jti: Optional[str]
+    "Unique identifier for the token."
 
     auth_time: Optional[int]
     "Time when the End-User authentication occurred Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time When a max_age request is made or when auth_time is requested as an Essential Claim, then this Claim is REQUIRED; otherwise, its inclusion is OPTIONAL (The auth_time Claim semantically corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] auth_time response parameter.)"

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -296,7 +296,7 @@ class IdToken(OpenidBaseModel):
 
 class JwtAccessToken(OpenidBaseModel):
     """
-    The content that might be encoded into an access token according to `RFC 9068 <https://www.rfc-editor.org/rfc/rfc9068`_.
+    The content that might be encoded into an access token according to `RFC 9068 <https://www.rfc-editor.org/rfc/rfc9068>`_.
 
     The specification defines a profile for issuing access tokens in JSON Web Token (JWT) format.
     Authorization servers from different vendors may leverage this profile to issue access tokens in an interoperable

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -337,6 +337,24 @@ class JwtAccessToken(OpenidBaseModel):
     amr: Optional[List[str]]
     "OPTIONAL. Authentication Methods References JSON array of strings that are identifiers for authentication methods used in the authentication For instance, values might indicate that both password and OTP authentication methods were used The definition of particular values to be used in the amr Claim is beyond the scope of this specification Parties using this claim will need to agree upon the meanings of the values used, which may be context-specific The amr value is an array of case sensitive strings."
 
+    scope: Optional[str]
+    "OPTIONAL. Scopes to which the token grants access. Multiple scopes are encoded space separated. If the openid scope value is not present, the behavior is entirely unspecified. Other scope values MAY be present."
+
+    def validate_extern(self, issuer: str) -> None:
+        """
+        Validate this Access-Token with external data for consistency.
+
+        :param issuer: The issuer that this token is supposed to originate from.
+            Should usually be :data:`ProviderMetadata.issuer`.
+        """
+        # validate issuer
+        validate_that(
+            self.iss == issuer, "Access-Token was issued from unexpected issuer"
+        )
+
+        # validate expiry
+        validate_that(self.exp > time.time(), "The Access-Token is expired")
+
 
 class UserinfoRequest(OpenidBaseModel):
     """

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -294,6 +294,50 @@ class IdToken(OpenidBaseModel):
             )
 
 
+class JwtAccessToken(OpenidBaseModel):
+    """
+    The content that might be encoded into an access token according to `RFC 9068 <https://www.rfc-editor.org/rfc/rfc9068`_.
+
+    The specification defines a profile for issuing access tokens in JSON Web Token (JWT) format.
+    Authorization servers from different vendors may leverage this profile to issue access tokens in an interoperable
+    manner but they are in no way required to do so.
+    """
+
+    class Config:
+        extra = Extra.allow
+        allow_mutation = False
+
+    iss: AnyHttpUrl
+    "REQUIRED. The 'iss' (issuer) claim identifies the principal that issued the JWT. The processing of this claim is generally application specific. The 'iss' value is a case-sensitive string containing a StringOrURI value."
+
+    exp: int
+    "REQUIRED. The 'exp' (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. The processing of the 'exp' claim requires that the current date/time MUST be before the expiration date/time listed in the 'exp' claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value."
+
+    aud: str
+    "REQUIRED. The 'aud' (audience) claim identifies the recipients that the JWT is intended for. Each principal intended to process the JWT MUST identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the 'aud' claim when this claim is present, then the JWT MUST be rejected. In the general case, the 'aud' value is an array of case-sensitive strings, each containing a StringOrURI value. In the special case when the JWT has one audience, the 'aud' value MAY be a single case-sensitive string containing a StringOrURI value. The interpretation of audience values is generally application specific."
+
+    sub: str
+    "REQUIRED. Subject Identifier A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4 It MUST NOT exceed 255 ASCII characters in length The sub value is a case sensitive string."
+
+    client_id: str
+    "REQUIRED. The client_id claim carries the client identifier of the OpenId client that requested the token."
+
+    iat: int
+    "REQUIRED. As defined in Section 4.1.6 of [RFC7519]. This claim identifies the time at which the JWT access token was issued."
+
+    jti: str
+    "REQUIRED. Unique identifier for the token."
+
+    auth_time: Optional[int]
+    "Time when the End-User authentication occurred Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time When a max_age request is made or when auth_time is requested as an Essential Claim, then this Claim is REQUIRED; otherwise, its inclusion is OPTIONAL (The auth_time Claim semantically corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] auth_time response parameter.)"
+
+    acr: Optional[str]
+    "OPTIONAL. Authentication Context Class Reference String specifying an Authentication Context Class Reference value that identifies the Authentication Context Class that the authentication performed satisfied. The value '0' indicates the End-User authentication did not meet the requirements of ISO/IEC 29115 [ISO29115] level 1. Authentication using a long-lived browser cookie, for instance, is one example where the use of 'level 0' is appropriate. Authentications with level 0 SHOULD NOT be used to authorize access to any resource of any monetary value (This corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] nist_auth_level 0.)  An absolute URI or an RFC 6711 [RFC6711] registered name SHOULD be used as the acr value; registered names MUST NOT be used with a different meaning than that which is registered Parties using this claim will need to agree upon the meanings of the values used, which may be context-specific The acr value is a case sensitive string."
+
+    amr: Optional[List[str]]
+    "OPTIONAL. Authentication Methods References JSON array of strings that are identifiers for authentication methods used in the authentication For instance, values might indicate that both password and OTP authentication methods were used The definition of particular values to be used in the amr Claim is beyond the scope of this specification Parties using this claim will need to agree upon the meanings of the values used, which may be context-specific The amr value is an array of case sensitive strings."
+
+
 class UserinfoRequest(OpenidBaseModel):
     """
     A request that can be sent to an OP to request information about a user

--- a/src/simple_openid_connect/integrations/django/apps.py
+++ b/src/simple_openid_connect/integrations/django/apps.py
@@ -15,7 +15,7 @@ from django.utils.module_loading import import_string
 from pydantic import BaseModel
 
 from simple_openid_connect.client import OpenidClient
-from simple_openid_connect.data import IdToken
+from simple_openid_connect.data import IdToken, JwtAccessToken
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ class OpenidAppConfig(AppConfig):
         return import_string(self.safe_settings.OPENID_CREATE_USER_FUNC)  # type: ignore
 
     @property
-    def update_user_func(self) -> Callable[[Any, IdToken], None]:
+    def update_user_func(self) -> Callable[[Any, Union[IdToken, JwtAccessToken]], None]:
         """
         The function which is configured via django settings and which updates user objects based on id tokens.
         """

--- a/src/simple_openid_connect/integrations/django/decorators.py
+++ b/src/simple_openid_connect/integrations/django/decorators.py
@@ -77,74 +77,15 @@ def access_token_required(
             oidc_client = OpenidAppConfig.get_instance().get_client(request)
             raw_token = request.headers["Authorization"].split(" ", 1)[1]
 
-            # try to parse the token as JWT based access token
             try:
-                token = JwtAccessToken.parse_jwt(
-                    raw_token,
-                    oidc_client.provider_keys,
-                    oidc_client.provider_config.issuer,
+                (
+                    request.user,
+                    _,
+                ) = OpenidAppConfig.get_instance().user_mapper.handle_federated_access_token(
+                    raw_token, oidc_client, _required_scopes
                 )
-                try:
-                    token.validate_extern(oidc_client.provider_config.issuer)
-                except ValidationError:
-                    return _invalid_token_response(request)
-
-                # verify the tokens scope
-                if token.scope is None:
-                    logger.critical(
-                        "parsed access token as valid JWT but it did not contain a scopes claim"
-                    )
-                    raise Exception()  # fall back to introspection
-                elif any(
-                    scope not in token.scope.split(" ")
-                    for scope in _required_scopes.split(" ")
-                ):
-                    return _invalid_token_response(request)
-
-                # if the token contains user information, add it to the request
-                if token.sub is not None and hasattr(token, "username"):
-                    request.user = models.OpenidUser.objects.get_or_create_for_sub(
-                        token.sub, token.username
-                    ).user
-                    OpenidAppConfig.get_instance().update_user_func(request.user, token)
-
-            # fall back to introspecting the token at the issuer
-            except Exception:
-                logger.debug(
-                    "Could not parse token as JWT, trying token introspection next"
-                )
-
-                # introspect passed token
-                introspect_response = oidc_client.introspect_token(raw_token)
-
-                if isinstance(introspect_response, TokenIntrospectionErrorResponse):
-                    logger.critical(
-                        "could not introspect token for validity: %s",
-                        introspect_response,
-                    )
-                    return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
-
-                # return an error if the token is expired
-                if not introspect_response.active:
-                    return _invalid_token_response(request)
-
-                # validate token scope for required access
-                if introspect_response.scope is None:
-                    logger.critical(
-                        "could not determine access because token introspection did not return token scopes"
-                    )
-                    return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
-                elif any(
-                    scope not in introspect_response.scope.split(" ")
-                    for scope in _required_scopes.split(" ")
-                ):
-                    return _invalid_token_response(request)
-
-                # if the introspection response contains user information, add it to the request
-                if introspect_response.sub is not None:
-                    request.user = models.OpenidUser.objects.get_or_create_for_sub(
-                        introspect_response.sub, introspect_response.username
-                    ).user
+            except ValidationError:
+                return _invalid_token_response(request)
 
             # execute the decorated view function
             return view_func(request, *args, **kwargs)

--- a/src/simple_openid_connect/integrations/django/decorators.py
+++ b/src/simple_openid_connect/integrations/django/decorators.py
@@ -10,7 +10,8 @@ from typing import Any, Callable, Optional, TypeVar, Union
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
-from simple_openid_connect.data import TokenIntrospectionErrorResponse
+from simple_openid_connect.data import JwtAccessToken, TokenIntrospectionErrorResponse
+from simple_openid_connect.exceptions import ValidationError
 from simple_openid_connect.integrations.django import models
 from simple_openid_connect.integrations.django.apps import OpenidAppConfig
 from simple_openid_connect.utils import is_application_json
@@ -73,38 +74,77 @@ def access_token_required(
                     headers={"WWW-Authenticate": "Bearer"},
                 )
 
-            # introspect passed token
-            token = request.headers["Authorization"].split(" ", 1)[1]
             oidc_client = OpenidAppConfig.get_instance().get_client(request)
-            introspect_response = oidc_client.introspect_token(token)
+            raw_token = request.headers["Authorization"].split(" ", 1)[1]
 
-            if isinstance(introspect_response, TokenIntrospectionErrorResponse):
-                logger.critical(
-                    "could not introspect token for validity: %s", introspect_response
+            # try to parse the token as JWT based access token
+            try:
+                token = JwtAccessToken.parse_jwt(
+                    raw_token,
+                    oidc_client.provider_keys,
+                    oidc_client.provider_config.issuer,
                 )
-                return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+                try:
+                    token.validate_extern(oidc_client.provider_config.issuer)
+                except ValidationError:
+                    return _invalid_token_response(request)
 
-            # return an error if the token is expired
-            if not introspect_response.active:
-                return _invalid_token_response(request)
+                # verify the tokens scope
+                if token.scope is None:
+                    logger.critical(
+                        "parsed access token as valid JWT but it did not contain a scopes claim"
+                    )
+                    raise Exception()  # fall back to introspection
+                elif any(
+                    scope not in token.scope.split(" ")
+                    for scope in _required_scopes.split(" ")
+                ):
+                    return _invalid_token_response(request)
 
-            # validate token scope for required access
-            if introspect_response.scope is None:
-                logger.critical(
-                    "could not determine access because token introspection did not return token scopes"
+                # if the token contains user information, add it to the request
+                if token.sub is not None and hasattr(token, "username"):
+                    request.user = models.OpenidUser.objects.get_or_create_for_sub(
+                        token.sub, token.username
+                    ).user
+                    OpenidAppConfig.get_instance().update_user_func(request.user, token)
+
+            # fall back to introspecting the token at the issuer
+            except Exception:
+                logger.debug(
+                    "Could not parse token as JWT, trying token introspection next"
                 )
-                return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
-            elif any(
-                scope not in introspect_response.scope.split(" ")
-                for scope in _required_scopes.split(" ")
-            ):
-                return _invalid_token_response(request)
 
-            # if the introspection response contains user information, add it to the request
-            if introspect_response.sub is not None:
-                request.user = models.OpenidUser.objects.get_or_create_for_sub(
-                    introspect_response.sub, introspect_response.username
-                ).user
+                # introspect passed token
+                introspect_response = oidc_client.introspect_token(raw_token)
+
+                if isinstance(introspect_response, TokenIntrospectionErrorResponse):
+                    logger.critical(
+                        "could not introspect token for validity: %s",
+                        introspect_response,
+                    )
+                    return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+                # return an error if the token is expired
+                if not introspect_response.active:
+                    return _invalid_token_response(request)
+
+                # validate token scope for required access
+                if introspect_response.scope is None:
+                    logger.critical(
+                        "could not determine access because token introspection did not return token scopes"
+                    )
+                    return HttpResponse(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+                elif any(
+                    scope not in introspect_response.scope.split(" ")
+                    for scope in _required_scopes.split(" ")
+                ):
+                    return _invalid_token_response(request)
+
+                # if the introspection response contains user information, add it to the request
+                if introspect_response.sub is not None:
+                    request.user = models.OpenidUser.objects.get_or_create_for_sub(
+                        introspect_response.sub, introspect_response.username
+                    ).user
 
             # execute the decorated view function
             return view_func(request, *args, **kwargs)

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -113,7 +113,7 @@ class UserMapper:
         )  # type: JwtAccessToken | TokenIntrospectionSuccessResponse | None
         try:
             # parse an validate the general token structure
-            token = JwtAccessToken.parse_jws(
+            token = JwtAccessToken.parse_jwt(
                 access_token,
                 oidc_client.provider_keys,
             )

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -2,16 +2,16 @@
 Default implementations for mapping tokens to user objects
 """
 
-from typing import Any, Mapping, Type
+from typing import Any, Mapping, Type, Union
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser, AbstractUser
 
-from simple_openid_connect.data import IdToken
+from simple_openid_connect.data import IdToken, JwtAccessToken
 
 
 def automap_user_attrs(
-    user_t: Type["AbstractBaseUser"], id_token: IdToken
+    user_t: Type["AbstractBaseUser"], id_token: Union[IdToken, JwtAccessToken]
 ) -> Mapping[str, Any]:
     """
     Inspect the given user model, discover its attributes based on some heuristics and fetch their values from the id token.
@@ -55,7 +55,7 @@ def create_user_from_token(id_token: IdToken) -> Any:
     return user_t.objects.create(**user_attrs)
 
 
-def update_user_from_token(user: Any, id_token: IdToken) -> None:
+def update_user_from_token(user: Any, id_token: Union[IdToken, JwtAccessToken]) -> None:
     """
     Implementation for updating an existing user object with new data
 

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -120,15 +120,18 @@ class UserMapper:
             token.validate_extern(oidc_client.provider_config.issuer)
 
             # validate token scope for required access
-            if token.scope is None:
-                raise ValidationError("token does not contain required scopes claim")
-            elif any(
-                i_scope not in token.scope.split(" ")
-                for i_scope in required_scopes.split(" ")
-            ):
-                raise ValidationError(
-                    f"token has access to scopes '{token.scope}' but '{required_scopes}' are required"
-                )
+            if required_scopes != "":
+                if token.scope is None:
+                    raise ValidationError(
+                        "token does not contain required scopes claim"
+                    )
+                elif any(
+                    i_scope not in token.scope.split(" ")
+                    for i_scope in required_scopes.split(" ")
+                ):
+                    raise ValidationError(
+                        f"token has access to scopes '{token.scope}' but '{required_scopes}' are required"
+                    )
 
             # the token is determined to be valid, so we can use it as user_data
             user_data = token

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -196,6 +196,8 @@ class UserMapper:
             # username
             if hasattr(user_data, "preferred_username"):
                 setattr(user, user.USERNAME_FIELD, user_data.preferred_username)
+            elif hasattr(user_data, "username"):
+                setattr(user, user.USERNAME_FIELD, user_data.username)
             # email
             if hasattr(user_data, "email"):
                 setattr(user, user.EMAIL_FIELD, user_data.email)

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -113,10 +113,9 @@ class UserMapper:
         )  # type: JwtAccessToken | TokenIntrospectionSuccessResponse | None
         try:
             # parse an validate the general token structure
-            token = JwtAccessToken.parse_jwt(
+            token = JwtAccessToken.parse_jws(
                 access_token,
                 oidc_client.provider_keys,
-                oidc_client.provider_config.issuer,
             )
             token.validate_extern(oidc_client.provider_config.issuer)
 

--- a/src/simple_openid_connect/integrations/django/user_mapping.py
+++ b/src/simple_openid_connect/integrations/django/user_mapping.py
@@ -100,7 +100,7 @@ class UserMapper:
             If ``None`` is passed, the default scopes from django settings ``OPENID_SCOPE`` are used.
             Pass an empty string if no scopes are required.
 
-        :returns: An instance of the applications user model.
+        :returns: An instance of the applications user model as well as additional data about the user.
 
         :raises ValidationError: If the passed token cannot be validated or is decidedly invalid.
         """

--- a/src/simple_openid_connect/integrations/django/views.py
+++ b/src/simple_openid_connect/integrations/django/views.py
@@ -76,7 +76,7 @@ class LoginCallbackView(View):
             )
 
         # validate the received tokens
-        id_token = IdToken.parse_jws(token_response.id_token, client.provider_keys)
+        id_token = IdToken.parse_jwt(token_response.id_token, client.provider_keys)
         id_token.validate_extern(
             client.provider_config.issuer, client.client_auth.client_id
         )

--- a/src/simple_openid_connect/integrations/django/views.py
+++ b/src/simple_openid_connect/integrations/django/views.py
@@ -61,6 +61,7 @@ class LoginCallbackView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         client = OpenidAppConfig.get_instance().get_client(request)
 
+        # exchange the passed code for tokens
         token_response = client.authorization_code_flow.handle_authentication_result(
             current_url=request.get_full_path(),
         )
@@ -74,14 +75,17 @@ class LoginCallbackView(View):
                 status=HTTPStatus.UNAUTHORIZED,
             )
 
+        # validate the received tokens
         id_token = IdToken.parse_jws(token_response.id_token, client.provider_keys)
         id_token.validate_extern(
             client.provider_config.issuer, client.client_auth.client_id
         )
 
-        user = OpenidUser.objects.get_or_create_from_id_token(id_token)
-        user.update_session(token_response)
-        login(request, user.user, backend=settings.AUTHENTICATION_BACKENDS[0])
+        # handle federated user information (create a new user if necessary or update local info) and log the user in
+        user = OpenidAppConfig.get_instance().user_mapper.handle_federated_userinfo(
+            id_token
+        )
+        login(request, user, backend=settings.AUTHENTICATION_BACKENDS[0])
 
         # redirect to the next get parameter if present, otherwise to the configured default
         if "login_redirect_url" in request.session.keys():

--- a/src/simple_openid_connect/integrations/djangorestframework/permissions.py
+++ b/src/simple_openid_connect/integrations/djangorestframework/permissions.py
@@ -75,10 +75,13 @@ class HasTokenScope(_HasScope):  # type: ignore
             request.auth, AuthenticatedViaToken
         ):
             logger.error(
-                "token permission is supposed to be checked but the request was not authenticated appropriately with an access token; denying access"
+                "token permission is supposed to be checked but the request was not authenticated via an access token; denying access"
             )
             return False
-        if request.auth.token_introspection.scope is None:
+        if (
+            not hasattr(request.auth.user_data, "scope")
+            or request.auth.user_data.scope is None
+        ):
             logger.error(
                 "token permission could not be checked because the token introspection does not contain token scopes; denying access"
             )
@@ -86,6 +89,4 @@ class HasTokenScope(_HasScope):  # type: ignore
 
         # authorize the request
         required_scopes = self._get_required_scopes(view)
-        return self._validate_scopes(
-            required_scopes, request.auth.token_introspection.scope
-        )
+        return self._validate_scopes(required_scopes, request.auth.user_data.scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,7 +118,7 @@ def dummy_auth_response(response_mock):
     Mocked response for the authorization endpoint
 
     - endpoint url: `https://provider.example.com/auth`
-    - client_id: `client-id`
+    - client_id: `test-client-id`
     - valid redirect_uri: `https://app.example.com/login-callback`
     - returned code: `code.foobar123`
     """
@@ -127,7 +127,7 @@ def dummy_auth_response(response_mock):
         match=[
             matchers.query_param_matcher(
                 {
-                    "client_id": "client-id",
+                    "client_id": "test-client-id",
                     "redirect_uri": "https://app.example.com/login-callback",
                     "response_type": "code",
                     "scope": "openid",
@@ -147,7 +147,7 @@ def dummy_token_response(response_mock):
     Mocked response for the token endpoint
 
     - endpoint url: `https://provider.example.com/token`
-    - client_id: `client-id`
+    - client_id: `test-client-id`
     - client_secret: `client-secret`
     - valid redirect_uri: `https://app.example.com/login-callback`
     - expected code: `code.foobar123`
@@ -160,7 +160,7 @@ def dummy_token_response(response_mock):
         match=[
             matchers.urlencoded_params_matcher(
                 {
-                    "client_id": "client-id",
+                    "client_id": "test-client-id",
                     "code": "code.foobar123",
                     "grant_type": "authorization_code",
                     "redirect_uri": "https://app.example.com/login-callback",
@@ -168,7 +168,7 @@ def dummy_token_response(response_mock):
             ),
             matchers.header_matcher(
                 {
-                    "Authorization": f"Basic {b64encode(b'client-id:client-secret').decode()}",
+                    "Authorization": f"Basic {b64encode(b'test-client-id:test-client-secret').decode()}",
                 }
             ),
         ],
@@ -235,7 +235,7 @@ def dummy_token_introspection_response(response_mock):
 
     - endpoint url: `https://provider.example.com/token-introspection`
     - access token: `access_token.foobar123`
-    - client credentials: `client-id` & `client-secret`
+    - client credentials: `test-client-id` & `test-client-secret`
 
     - returned: `active=true`
 
@@ -251,7 +251,7 @@ def dummy_token_introspection_response(response_mock):
             ),
             matchers.header_matcher(
                 {
-                    "Authorization": f"Basic {b64encode(b'client-id:client-secret').decode()}",
+                    "Authorization": f"Basic {b64encode(b'test-client-id:test-client-secret').decode()}",
                 }
             ),
         ],
@@ -264,7 +264,7 @@ def dummy_token_introspection_response(response_mock):
         match=[
             matchers.header_matcher(
                 {
-                    "Authorization": f"Basic {b64encode(b'client-id:client-secret').decode()}",
+                    "Authorization": f"Basic {b64encode(b'test-client-id:test-client-secret').decode()}",
                 }
             )
         ],

--- a/tests/django_test_project/django_test_project/settings.py
+++ b/tests/django_test_project/django_test_project/settings.py
@@ -92,10 +92,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_REDIRECT_URL = "default-after-login"
 
-OPENID_BASE_URI = "http://localhost:8000"
-OPENID_ISSUER = "http://localhost:3000"
-OPENID_CLIENT_ID = "test-client"
-OPENID_CLIENT_SECRET = "foobar123"
+OPENID_BASE_URI = "https://app.example.com"
+OPENID_ISSUER = "https://provider.example.com"
+OPENID_CLIENT_ID = "test-client-id"
+OPENID_CLIENT_SECRET = "test-client-secret"
 OPENID_SCOPE = "openid profile email"
 
 LOGIN_URL = "simple_openid_connect:login"

--- a/tests/django_test_project/django_test_project/tests/test_access_token_protected_view.py
+++ b/tests/django_test_project/django_test_project/tests/test_access_token_protected_view.py
@@ -14,6 +14,7 @@ def test_invalid_token_text(
     dummy_provider_settings,
     dummy_provider_config,
     dummy_token_introspection_response,
+    response_mock,
 ):
     # act
     response = client.get(

--- a/tests/test_authorization_code_flow.py
+++ b/tests/test_authorization_code_flow.py
@@ -10,7 +10,7 @@ def test_authorization_request(user_agent, dummy_auth_response):
     url = authorization_code_flow.start_authentication(
         "https://provider.example.com/auth",
         "openid",
-        "client-id",
+        "test-client-id",
         "https://app.example.com/login-callback",
     )
     response = user_agent.naviagte_to(url)
@@ -29,8 +29,8 @@ def test_token_exchange(user_agent, dummy_token_response):
         AuthenticationSuccessResponse(code="code.foobar123"),
         "https://app.example.com/login-callback",
         ClientSecretBasicAuth(
-            "client-id",
-            "client-secret",
+            "test-client-id",
+            "test-client-secret",
         ),
     )
 
@@ -44,7 +44,7 @@ def test_handle_authentication_result(user_agent, dummy_token_response):
     response = authorization_code_flow.handle_authentication_result(
         "https://app.example.com/login-callback?code=code.foobar123",
         "https://provider.example.com/token",
-        ClientSecretBasicAuth("client-id", "client-secret"),
+        ClientSecretBasicAuth("test-client-id", "test-client-secret"),
     )
 
     # assert

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,8 +16,8 @@ def make_client() -> OpenidClient:
     return OpenidClient.from_issuer_url(
         url="https://provider.example.com",
         authentication_redirect_uri="https://app.example.com/login-callback",
-        client_id="client-id",
-        client_secret="client-secret",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
     )
 
 


### PR DESCRIPTION
Originally I found that there is a spec which defines the structure of JWT based access tokens ([RFC9068](https://www.rfc-editor.org/rfc/rfc9068)) which is what most OpenID providers (including Keycloak) seem to use. While implementing it I noticed some problems with the code that maps federated users to local users which I then refactored.

I realize this is not optimal but because of that the PR includes two parts:
- A definition of a RFC9068 based access token model as well as code to handle it.
- A refactor of user mapping code. The big change is that we now support hooking into the user mapping procedure when the server is running as a resource server (in contrast to being a relying party which was supported before). 
For details about how the new process is implemented I suggest looking at the documentation in `docs/django-integration.rst` and `src/simple_openind_connect/integrations/django/user_mapping.py` which were both updated to match the new system.
