### PR TITLE
Add support for client credentials grant

### DIFF
--- a/src/simple_openid_connect/client.py
+++ b/src/simple_openid_connect/client.py
@@ -46,6 +46,9 @@ from simple_openid_connect.exceptions import UnsupportedByProviderError
 from simple_openid_connect.flows.authorization_code_flow.client import (
     AuthorizationCodeFlowClient,
 )
+from simple_openid_connect.flows.client_credentials_grant.client import (
+    ClientCredentialsGrantClient,
+)
 from simple_openid_connect.flows.direct_access_grant.client import (
     DirectAccessGrantClient,
 )
@@ -69,6 +72,9 @@ class OpenidClient:
     direct_access_grant: DirectAccessGrantClient
     "*Direct Access Grant* (or *Resource Owner Password Credentials Grant*) functionality"
 
+    client_credentials_grant: ClientCredentialsGrantClient
+    "*Client Credentials Grant* (or *Service Account Authentication*) functionality"
+
     def __init__(
         self,
         provider_config: ProviderMetadata,
@@ -82,6 +88,7 @@ class OpenidClient:
         self.provider_keys = provider_keys
         self.authorization_code_flow = AuthorizationCodeFlowClient(self)
         self.direct_access_grant = DirectAccessGrantClient(self)
+        self.client_credentials_grant = ClientCredentialsGrantClient(self)
         self.scope = scope
         self.authentication_redirect_uri = authentication_redirect_uri
 

--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -492,7 +492,12 @@ class TokenRequest(OpenidBaseModel):
     class Config:
         extra = Extra.allow
 
-    grant_type: Union[Literal["authorization_code", "refresh_token", "password"], str]
+    grant_type: Union[
+        Literal[
+            "authorization_code", "refresh_token", "password", "client_credentials"
+        ],
+        str,
+    ]
     "REQUIRED. Which type of token exchange this request is."
 
     code: Optional[str] = None

--- a/src/simple_openid_connect/flows/client_credentials_grant/__init__.py
+++ b/src/simple_openid_connect/flows/client_credentials_grant/__init__.py
@@ -1,0 +1,51 @@
+"""
+The `*Client Credentials Grant* <https://oauth.net/2/grant-types/client-credentials/>`_ (sometimes called Service Account Authentication) implementation.
+
+This grant enables a client to retrieve tokens dedicated to the client and not to a specific user.
+"""
+import logging
+from typing import Union
+
+import requests
+
+from simple_openid_connect.client_authentication import ClientAuthenticationMethod
+from simple_openid_connect.data import (
+    TokenErrorResponse,
+    TokenRequest,
+    TokenSuccessResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def authenticate(
+    token_endpoint: str, scope: str, client_authentication: ClientAuthenticationMethod
+) -> Union[TokenSuccessResponse, TokenErrorResponse]:
+    """
+    Retrieve a token that is dedicated to the authenticated client from the provider.
+
+    :param token_endpoint: The endpoint of the OP at which tokens can be exchanged.
+        Corresponds to :data:`ProviderMetadata.token_endpoint <simple_openid_connect.data.ProviderMetadata.token_endpoint>`.
+    :param scope: The scope requested by the application.
+    :param client_authentication: A way for the client to authenticate itself.
+
+    :returns: The result of the exchange
+    """
+    logger.debug(
+        f"requesting access via client credentials grant as client {client_authentication.client_id}"
+    )
+    request_msg = TokenRequest(
+        grant_type="client_credentials",
+        scope=scope,
+    )
+    response = requests.post(
+        token_endpoint,
+        data=request_msg.encode_x_www_form_urlencoded(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        auth=client_authentication,
+    )
+
+    if response.status_code == 200:
+        return TokenSuccessResponse.parse_raw(response.content)
+    else:
+        return TokenErrorResponse.parse_raw(response.content)

--- a/src/simple_openid_connect/flows/client_credentials_grant/client.py
+++ b/src/simple_openid_connect/flows/client_credentials_grant/client.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING, Union
+
+from simple_openid_connect.data import TokenErrorResponse, TokenSuccessResponse
+from simple_openid_connect.exceptions import UnsupportedByProviderError
+from simple_openid_connect.flows import client_credentials_grant as impl
+
+if TYPE_CHECKING:
+    from simple_openid_connect.client import OpenidClient
+
+
+class ClientCredentialsGrantClient:
+    """
+    A client that implements `*Client Credentials Grant* <https://oauth.net/2/grant-types/client-credentials/>`_ (sometimes called Service Account Authentication).
+
+    It is exposed via :data:`OpenidClient.client_credentials_grant <simple_openid_connect.client.OpenidClient.client_credentials_grant>`
+    """
+
+    def __init__(self, base_client: "OpenidClient"):
+        self._base_client = base_client
+
+    def authenticate(self) -> Union[TokenSuccessResponse, TokenErrorResponse]:
+        """
+        Retrieve a token that is dedicated to the authenticated client from the provider.
+
+        :returns: The result of the exchange
+        """
+        if self._base_client.provider_config.token_endpoint is None:
+            raise UnsupportedByProviderError(
+                f"The OpenID provider {self._base_client.provider_config.issuer} only seems to support the implicit flow and does not have a token endpoint"
+            )
+
+        return impl.authenticate(
+            token_endpoint=self._base_client.provider_config.token_endpoint,
+            scope=self._base_client.scope,
+            client_authentication=self._base_client.client_auth,
+        )

--- a/tests/test_client_credentials_grant.py
+++ b/tests/test_client_credentials_grant.py
@@ -1,0 +1,44 @@
+from base64 import b64encode
+
+import pytest
+from responses import matchers
+
+from simple_openid_connect.client_authentication import ClientSecretBasicAuth
+from simple_openid_connect.flows import client_credentials_grant
+
+
+@pytest.fixture
+def dummy_token_response(response_mock):
+    response_mock.post(
+        url="https://provider.example.com/token",
+        match=[
+            matchers.urlencoded_params_matcher(
+                {
+                    "grant_type": "client_credentials",
+                    "scope": "openid",
+                }
+            ),
+            matchers.header_matcher(
+                {
+                    "Authorization": f"Basic {b64encode(b'client-id:client-secret').decode()}",
+                }
+            ),
+        ],
+        json={
+            "access_token": "access_token.foobar123",
+            "token_type": "Bearer",
+            "id_token": "id_token.foobar123",
+        },
+    )
+
+
+def test_auth_exchange(user_agent, dummy_token_response):
+    # act
+    response = client_credentials_grant.authenticate(
+        "https://provider.example.com/token",
+        "openid",
+        ClientSecretBasicAuth("client-id", "client-secret"),
+    )
+
+    # assert
+    assert response.access_token


### PR DESCRIPTION
OAuth (and therefore OpenID Connect) specifies a [client credentials grant](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/) with which an authenticated client can request access tokens that are issued to the client itself and not to a specific user.
This is useful to for example support service account functionality.

This PR implements support for that grant type.