### PR TITLE
Fix infinite redirect in token verification if login page is accessed

### DIFF
--- a/src/simple_openid_connect/integrations/django/middleware.py
+++ b/src/simple_openid_connect/integrations/django/middleware.py
@@ -20,10 +20,17 @@ class TokenVerificationMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
+
+        # if we are already trying to log in, no redirect should happen
+        if request.path == resolve_url(settings.LOGIN_URL):
+            return response
+
+        # if the user is not logged in, also no redirect should happen
         openid_session_id = request.session.get("openid_session")
         if not openid_session_id:
             return response
 
+        # the refresh token has a long validity, the access token expires quickly
         openid_session = OpenidSession.objects.get(id=openid_session_id)
         refresh_token = openid_session.refresh_token
         session_valid_until = openid_session.access_token_expiry
@@ -31,9 +38,11 @@ class TokenVerificationMiddleware:
             session_valid_until is not None
             and session_valid_until > datetime.now(timezone.utc)
         )
+        # if the access token is valid, everything is fine
         if access_token_valid:
             return response
 
+        # try to refresh the access token with the refresh token
         logger.debug("access token expired, trying to refresh")
         client = OpenidAppConfig.get_instance().get_client(request)
         exchange_response = client.exchange_refresh_token(refresh_token)
@@ -42,4 +51,5 @@ class TokenVerificationMiddleware:
             openid_session.save()
             return response
         else:
+            # the refresh token is also expired, redirect to login
             return HttpResponseRedirect(resolve_url(settings.LOGIN_URL))


### PR DESCRIPTION
If a user tries to log in (or an application redirects to login) when the access token and refresh token are both expired, the middleware currently redirects to the login url again, causing an infinite redirect. This fixes the issue and adds some documentation to the code.