### PR TITLE
Deserialization alias for client_id from azp claim in JwtAccessTokens

### DIFF
--- a/src/simple_openid_connect/data.py
+++ b/src/simple_openid_connect/data.py
@@ -7,7 +7,7 @@ import logging
 import time
 from typing import Any, Callable, List, Literal, Mapping, Optional, Union
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator, AliasChoices
 
 from simple_openid_connect.base_data import OpenidBaseModel
 from simple_openid_connect.utils import validate_that
@@ -301,6 +301,11 @@ class JwtAccessToken(OpenidBaseModel):
     The specification defines a profile for issuing access tokens in JSON Web Token (JWT) format.
     Authorization servers from different vendors may leverage this profile to issue access tokens in an interoperable
     manner, but they are in no way required to do so.
+
+    .. note::
+
+       Some Identity Providers encode an ``azp`` claim (similar to :data:`IdToken.azp`) instead of :data:`client_id <JwtAccessToken.client_id>`.
+       Since both claims semantically contain the same information, tokens with an ``azp`` claim are normalized to contain ``client_id`` instead.
     """
 
     model_config = ConfigDict(extra="allow", frozen=True)
@@ -317,8 +322,8 @@ class JwtAccessToken(OpenidBaseModel):
     sub: str
     "Subject Identifier A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4 It MUST NOT exceed 255 ASCII characters in length The sub value is a case sensitive string."
 
-    client_id: str
-    "The client_id claim carries the client identifier of the OpenId client that requested the token."
+    client_id: str = Field(validation_alias=AliasChoices("client_id", "azp"))
+    "The client_id claim carries the client identifier of the OpenId client that requested the token. If a token contains an ``azp`` claim, that claim is deserialized into this field."
 
     iat: int
     "As defined in Section 4.1.6 of [RFC7519]. This claim identifies the time at which the JWT access token was issued."

--- a/tests/test_message_encoding.py
+++ b/tests/test_message_encoding.py
@@ -1,9 +1,10 @@
+import time
 import unittest
 from typing import Optional
 
 from hypothesis import given
 
-from simple_openid_connect.data import OpenidBaseModel
+from simple_openid_connect.data import OpenidBaseModel, JwtAccessToken
 
 
 class DummyMessage(OpenidBaseModel):
@@ -71,3 +72,44 @@ class UrlEncodingTestCase(unittest.TestCase):
         )
         # assert
         self.assertEqual(reconstructed_msg, msg)
+
+
+def test_jwt_access_token_with_azp_claim():
+    # arrange
+    now = int(time.time())
+    token_data = {
+        "iss": "https://provider.example.com",
+        "sub": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+        "jti": "test-token",
+        "iat": now,
+        "exp": now + 60 * 5,
+        "aud": "test-client",
+        "azp": "test-client",
+    }
+
+    # act
+    token = JwtAccessToken.model_validate(token_data)
+
+    # assert
+    assert token.client_id == "test-client"
+
+
+def test_jwt_access_token_with_azp_and_client_id_claim():
+    # arrange
+    now = int(time.time())
+    token_data = {
+        "iss": "https://provider.example.com",
+        "sub": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+        "jti": "test-token",
+        "iat": now,
+        "exp": now + 60 * 5,
+        "aud": ["test-client", "other-client"],
+        "azp": "other-client",
+        "client_id": "test-client",
+    }
+
+    # act
+    token = JwtAccessToken.model_validate(token_data)
+
+    # assert
+    assert token.client_id == "test-client"


### PR DESCRIPTION
Some Identity Providers were discovered to issue access tokens that are not strictly complying to the RFC and contain an azp claim instead of a client_id claim.
azp semantically contains the same information as client_id though so a deserialization alias has been added to increase compatibility with these Identity Providers.

Related Issue: https://github.com/fsinfuhh/py_simple_openid_connect/issues/43

@timhallmann is this what you expect?